### PR TITLE
Fix the generated epub file to be both more efficient and compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: sicp.epub
 
 sicp.epub: $(CONTENT)
 	cd src && zip -0Xq ../$@ mimetype
-	cd src && zip -r ../$@ $(^:src/%=%)
+	cd src && zip -Xr9D ../$@ $(^:src/%=%)
 
 check:
 	xmllint --noout $(XML)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ XML     := $(shell find src -type f -name \*html)
 all: sicp.epub
 
 sicp.epub: $(CONTENT)
+	echo -n application/epub+zip > src/mimetype
 	cd src && zip -0Xq ../$@ mimetype
+	rm src/mimetype
 	cd src && zip -Xr9D ../$@ $(^:src/%=%)
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ XML     := $(shell find src -type f -name \*html)
 all: sicp.epub
 
 sicp.epub: $(CONTENT)
+	cd src && zip -0Xq ../$@ mimetype
 	cd src && zip -r ../$@ $(^:src/%=%)
 
 check:

--- a/src/mimetype
+++ b/src/mimetype
@@ -1,1 +1,0 @@
-application/epub+zip


### PR DESCRIPTION
- Fixed the file so that it has the correct magic bytes at offsets 30 and 38.
- Made the generated epub ~ 400K smaller (over 50% reduction).

For details/reference, see:
- http://www.ibm.com/developerworks/xml/tutorials/x-epubtut/section4.html
- http://old.idpf.org/ocf/ocf1.0/download/ocf10.htm#_Ref134878301
