### PR TITLE
Fixing mimetype generation on Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 # TODO: Add potrace for gif -> svg conversion; convert still gives
 #       rasterized images
 
+#
+# On Mac OS X the default shell's echo does not understand -n, so we
+# need to force bash
+#
+ifeq ($(shell echo -n test && true),-n test)
+	SHELL := /bin/bash
+endif
+
+
 LATEX_DIR := src/latex
 IMAGES_DIR := src/OEBPS/images
 BUILD_DIR := $(LATEX_DIR)/build


### PR DESCRIPTION
In Mac OS X, Make defaults to /bin/sh, where `echo` doesn't understand the `-n` parameter (so the mimetype is set as "-n application/epub+zip"). 

This adds a check for the condition where `-n` isn't supported by default and forces bash as the `SHELL` if that is the case.
